### PR TITLE
Update format() function in LaravelShop.php

### DIFF
--- a/src/LaravelShop.php
+++ b/src/LaravelShop.php
@@ -274,7 +274,7 @@ class LaravelShop
             ],
             [
                 Config::get('shop.currency_symbol'),
-                $value,
+                sprintf("%01.2f", $value),
                 Config::get('shop.currency')
             ],
             Config::get('shop.display_price_format')


### PR DESCRIPTION
Added formatting of $value. Now "43.8" will be formatted as "€ 43.80".
